### PR TITLE
Fix timeout errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,7 +4048,10 @@ dependencies = [
  "fastcrypto",
  "mamoru-core",
  "move-core-types",
+ "rayon",
  "sui-types",
+ "tokio",
+ "tokio-rayon",
 ]
 
 [[package]]

--- a/crates/mamoru-sniffer/Cargo.toml
+++ b/crates/mamoru-sniffer/Cargo.toml
@@ -9,4 +9,7 @@ resolver = "2"
 fastcrypto = { workspace = true }
 mamoru-core = { workspace = true }
 move-core-types = { workspace = true }
+rayon = "1.5"
 sui-types = { path = "../sui-types" }
+tokio = { version = "1.20.1" }
+tokio-rayon = "2.1"

--- a/crates/sui-core/src/authority.rs
+++ b/crates/sui-core/src/authority.rs
@@ -2206,7 +2206,7 @@ impl AuthorityState {
             }
 
             if let Err(err) = sniffer
-                .observe_transaction(certificate, signed_effects, seq, now)
+                .observe_transaction(certificate.clone(), signed_effects.clone(), seq, now)
                 .await
             {
                 error!(?err, "Failed to observe transaction");

--- a/crates/sui-core/src/node_sync/node_state.rs
+++ b/crates/sui-core/src/node_sync/node_state.rs
@@ -43,8 +43,8 @@ const NODE_SYNC_QUEUE_LEN: usize = 500;
 // Process up to 20 digests concurrently.
 const MAX_NODE_SYNC_CONCURRENCY: usize = 20;
 
-// All tasks die after 60 seconds if they haven't finished.
-const MAX_NODE_TASK_LIFETIME: Duration = Duration::from_secs(60);
+// All tasks die after 180 seconds if they haven't finished.
+const MAX_NODE_TASK_LIFETIME: Duration = Duration::from_secs(180);
 
 // How long to wait for parents to be processed organically before fetching/executing them
 // directly.


### PR DESCRIPTION
Very large transactions like 
```
ogsTJFmmqiWdJra0PE84OLVlbkMMRoeR0PHEDNnxYQk=
JozERQ7eCEB3gDPfaee8j7zhmBYVEG5/pHUgoc9G958=
Q9UKK/6AQMQbZuBBGqIXi242vDTb/2D2mVhTWJ8FYZE=
```
were causing timeout error on our node.

- use rayon + don't block event loop
- increase task timeout